### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -109,11 +109,12 @@ if (typeof jQuery === 'undefined') {
       selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = $(selector)
-
-    if (e) e.preventDefault()
-
-    if (!$parent.length) {
+    var $parent;
+    if (selector && selector.charAt(0) === '#' && /^[#A-Za-z0-9\-_:.]+$/.test(selector)) {
+      // Only allow ID selectors
+      var el = document.getElementById(selector.slice(1));
+      $parent = $(el);
+    } else {
       $parent = $this.closest('.alert')
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/1](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/1)

To fix this issue, we should avoid passing untrusted data directly to the `$()` function, which can interpret the input as HTML and execute scripts. Instead, we should use a safer method to select elements, such as `document.querySelector`, or restrict the selector to only allow IDs (starting with `#`). Alternatively, we can use `closest` or `find` on a known ancestor element, or ensure that the selector is only ever used as a selector (not as HTML).

The best fix, as recommended by Bootstrap in later versions, is to use `document.getElementById` or restrict the selector to IDs. In this context, we can check if the selector starts with `#` and use `document.getElementById` to get the element, then wrap it in jQuery. If not, fall back to the original logic (e.g., use `closest('.alert')`). This prevents arbitrary HTML from being interpreted.

**What to change:**  
- In the `Alert.prototype.close` function, after determining `selector`, check if it is a valid ID selector (starts with `#` and contains only valid ID characters).
- If so, use `document.getElementById` to get the element, and wrap it in jQuery.
- If not, fall back to `$this.closest('.alert')`.

**What is needed:**  
- A function to validate the selector as an ID.
- Update the assignment to `$parent` to use this logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
