### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -503,7 +503,14 @@ if (typeof jQuery === 'undefined') {
   var clickHandler = function (e) {
     var href
     var $this   = $(this)
-    var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) // strip for ie7
+    var targetSelector = $this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, ''); // strip for ie7
+    // Only allow ID selectors (starting with # and containing valid characters)
+    var $target = null;
+    if (targetSelector && /^#[A-Za-z0-9\-_:.]+$/.test(targetSelector)) {
+      $target = $(document).find(targetSelector);
+    } else {
+      return;
+    }
     if (!$target.hasClass('carousel')) return
     var options = $.extend({}, $target.data(), $this.data())
     var slideIndex = $this.attr('data-slide-to')


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/2](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/2)

To fix this vulnerability, we should avoid passing untrusted input directly to the jQuery `$()` function, which can interpret the input as HTML and execute it. Instead, we should use a safer method to select the target element. The recommended approach is to use `document.getElementById` if the target is an ID selector, or jQuery's `.find()` method on a known safe parent element, which interprets the input only as a selector and not as HTML. In the context of Bootstrap's carousel, the `data-target` and `href` attributes typically refer to an element ID (e.g., `#myCarousel`). Therefore, we can safely select the target by extracting the ID and using `document.getElementById` or `$(document).find(target)`.

**Steps:**
- On line 506, instead of passing the raw attribute value to `$()`, extract the ID from the value (e.g., ensure it starts with `#` and contains only valid ID characters).
- Use `document.getElementById` or `$(document).find(target)` to select the element.
- Replace `$($this.attr('data-target') || ...)` with a safe selector.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
