### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -699,7 +699,7 @@ if (typeof jQuery === 'undefined') {
     var target = $trigger.attr('data-target')
       || (href = $trigger.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
 
-    return $(target)
+    return $(document).find(target)
   }
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/3](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/3)

To fix this vulnerability, we should avoid passing untrusted DOM text directly to the jQuery `$()` function, which can interpret the string as HTML and lead to XSS. Instead, we should use a safer method to select the target element. In this context, if `target` is intended to be a selector, we should use `.find()` on a known ancestor (such as `document` or a specific container), or otherwise ensure that the string is only interpreted as a selector and not as HTML. The best fix is to replace `return $(target)` with `return document.querySelector(target)` (if only one element is expected), or with `return $trigger.closest(target)` or `$(document).find(target)` if multiple elements or jQuery objects are needed. For compatibility with the rest of the code, using `$(document).find(target)` is the safest drop-in replacement.

Edit the function `getTargetFromTrigger` in Plugson/www/static/bootstrap/js/bootstrap.js, replacing `return $(target)` with `return $(document).find(target)`.

No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
