### PR TITLE
Potential fix for code scanning alert no. 13: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/SQUASHFS/squashfs-tools-4.4/squashfs-tools/mksquashfs.c
+++ b/SQUASHFS/squashfs-tools-4.4/squashfs-tools/mksquashfs.c
@@ -4856,13 +4856,13 @@ void read_recovery_data(char *recovery_file, char *destination_file)
 		BAD_ERROR("Failed to open recovery file because %s\n",
 			strerror(errno));
 
-	if(stat(destination_file, &buf) == -1)
-		BAD_ERROR("Failed to stat destination file, because %s\n",
-			strerror(errno));
-
 	fd = open(destination_file, O_RDWR);
 	if(fd == -1)
 		BAD_ERROR("Failed to open destination file because %s\n",
+			strerror(errno));
+
+	if(fstat(fd, &buf) == -1)
+		BAD_ERROR("Failed to stat destination file, because %s\n",
 			strerror(errno));
 
 	res = read_bytes(recoverfd, header2, RECOVER_ID_SIZE);


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/13](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/13)

To fix the TOCTOU race condition, we should avoid using `stat` on the filename and then opening the file by name. Instead, we should open the file first and then use `fstat` on the file descriptor to perform any necessary checks. This ensures that the file being checked is the same as the file being operated upon, eliminating the race window.

**Detailed steps:**
- Replace the `stat(destination_file, &buf)` call with `fd = open(destination_file, O_RDWR)` (move open before stat).
- After opening the file, use `fstat(fd, &buf)` to perform the same check as before.
- Ensure that all error handling is updated to reflect the new order.
- Only operate on the file descriptor after it has been opened and checked.

**Required changes:**
- Move the open call before the stat call.
- Replace stat with fstat, using the file descriptor.
- Update error handling to match the new order.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
