### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -781,7 +781,9 @@ if (typeof jQuery === 'undefined') {
       selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = selector && $(selector)
+    // Only allow selector if it is a safe CSS selector (starts with # or . and does not contain '<')
+    var isSafeSelector = selector && (/^#[\w-]+$/.test(selector) || (/^\.[\w-]+$/.test(selector))) && selector.indexOf('<') === -1;
+    var $parent = isSafeSelector ? $(selector) : $this.parent();
 
     return $parent && $parent.length ? $parent : $this.parent()
   }


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/4](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/4)

To fix this vulnerability, we must ensure that the value read from `data-target` (and `href`) is only ever interpreted as a CSS selector, not as HTML. The best way to do this is to use `$.find(selector)` or `$parent.find(selector)` instead of `$(selector)`, or to validate that the selector is a safe CSS selector (e.g., only IDs or classes, not HTML). However, in the context of Bootstrap's dropdown, the intent is to select an element by ID or class, so we should use `document.querySelector` or jQuery's `$.find` on a known safe parent (such as `document` or the dropdown's parent), or explicitly check that the selector starts with `#` or `.` and does not contain `<`.

The most robust fix is to ensure that `selector` is only used as a selector, never as HTML. We can do this by:
- Validating that `selector` starts with `#` (ID selector) or `.` (class selector), and does not contain `<`.
- If the selector is not safe, fall back to `$this.parent()`.

Edit the `getParent` function (lines 776-787) in Plugson/www/static/bootstrap/js/bootstrap.js to add this validation before using `$(selector)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
