### PR TITLE
Potential fix for code scanning alert no. 11: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/LinuxGUI/Ventoy2Disk/Lib/libhttp/include/civetweb.c
+++ b/LinuxGUI/Ventoy2Disk/Lib/libhttp/include/civetweb.c
@@ -7963,28 +7963,32 @@ delete_file(struct mg_connection *conn, const char *path)
 	}
 
 	/* This is an existing file (not a directory).
-	 * Check if write permission is granted. */
-	if (access(path, W_OK) != 0) {
-		/* File is read only */
-		send_http_error(
-		    conn,
-		    403,
-		    "Error: Delete not possible\nDeleting %s is not allowed",
-		    path);
-		return;
-	}
-
-	/* Try to delete it. */
+	 * Try to delete it directly and handle errors. */
 	if (mg_remove(conn, path) == 0) {
 		/* Delete was successful: Return 204 without content. */
 		send_http_error(conn, 204, "%s", "");
 	} else {
-		/* Delete not successful (file locked). */
-		send_http_error(conn,
-		                423,
-		                "Error: Cannot delete file\nremove(%s): %s",
-		                path,
-		                strerror(ERRNO));
+		/* Check the reason for failure. */
+		if (ERRNO == EACCES || ERRNO == EPERM) {
+			send_http_error(
+			    conn,
+			    403,
+			    "Error: Delete not possible\nDeleting %s is not allowed",
+			    path);
+		} else if (ERRNO == EBUSY || ERRNO == EAGAIN) {
+			send_http_error(conn,
+			                423,
+			                "Error: Cannot delete file\nremove(%s): %s",
+			                path,
+			                strerror(ERRNO));
+		} else {
+			send_http_error(conn,
+			                500,
+			                "Error: Could not delete %s\nremove(%s): %s",
+			                path,
+			                path,
+			                strerror(ERRNO));
+		}
 	}
 }
 #endif /* !NO_FILES */


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/11](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/11)

To fix the TOCTOU issue, the code should avoid checking permissions with `access()` before deleting the file, as this check is inherently racy. Instead, attempt to delete the file directly with `mg_remove(conn, path)`, and handle any errors that arise (such as permission denied) by checking the error code (`errno`). This way, the operation is performed atomically, and the result is based on the actual state of the file at the time of deletion. The error handling logic should be updated to distinguish between "permission denied" and other errors, so that the correct HTTP error code and message are returned. Only the code in the shown function (lines 7932–7989) needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
