### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -1240,7 +1240,8 @@ if (typeof jQuery === 'undefined') {
   $(document).on('click.bs.modal.data-api', '[data-toggle="modal"]', function (e) {
     var $this   = $(this)
     var href    = $this.attr('href')
-    var $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) // strip for ie7
+    var selector = $this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, '')); // strip for ie7
+    var $target = $(document).find(selector);
     var option  = $target.data('bs.modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data())
 
     if ($this.is('a')) e.preventDefault()


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/5](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/5)

To fix the vulnerability, we should avoid passing untrusted data directly to the jQuery `$()` function, which can interpret the string as HTML and execute scripts. Instead, we should use a method that only interprets the string as a selector, such as `.find()`, and ensure that the search is scoped to a known ancestor (e.g., `document` or a specific container). In this case, since the code is trying to find the modal target, we can use `document.getElementById()` if the selector is an ID, or use `$(document).find(selector)` to ensure the string is only interpreted as a selector, not as HTML. The fix should be applied to line 1243 in Plugson/www/static/bootstrap/js/bootstrap.js, replacing the use of `$()` with a safer alternative.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
