### PR TITLE
Potential fix for code scanning alert no. 7: Unsafe jQuery plugin

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -1310,7 +1310,13 @@ if (typeof jQuery === 'undefined') {
     this.type      = type
     this.$element  = $(element)
     this.options   = this.getOptions(options)
-    this.$viewport = this.options.viewport && $($.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport))
+    var viewportOption = $.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport);
+    if (typeof viewportOption === 'string') {
+      // Use find to ensure only CSS selectors are accepted, not HTML
+      this.$viewport = $(document).find(viewportOption);
+    } else {
+      this.$viewport = $(viewportOption);
+    }
     this.inState   = { click: false, hover: false, focus: false }
 
     if (this.$element[0] instanceof document.constructor && !this.options.selector) {


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/7](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/7)

To fix this issue, we need to ensure that the `viewport.selector` option is always interpreted as a CSS selector and never as HTML. The best way to do this is to use `jQuery.find()` instead of `$()` when the selector is a string, as `find()` only accepts CSS selectors and does not interpret HTML. If the selector is not a string (e.g., a DOM element or jQuery object), we can safely pass it to `$()`. The change should be made in the `Tooltip.prototype.init` method, specifically on line 1313, where the `this.$viewport` property is set. We should check the type of `this.options.viewport.selector` and use `find()` if it's a string, otherwise use `$()` as before. No new imports or methods are needed; just a change to this line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
