### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe jQuery plugin

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -2234,7 +2234,7 @@ if (typeof jQuery === 'undefined') {
   var Affix = function (element, options) {
     this.options = $.extend({}, Affix.DEFAULTS, options)
 
-    this.$target = $(this.options.target)
+    this.$target = $(document).find(this.options.target)
       .on('scroll.bs.affix.data-api', $.proxy(this.checkPosition, this))
       .on('click.bs.affix.data-api',  $.proxy(this.checkPositionWithEventLoop, this))
 


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/8](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/8)

To fix the problem, we should ensure that the `target` option is always interpreted as a CSS selector, not as HTML. The best way to do this is to use `jQuery.find()` instead of `jQuery()` when selecting the target element, or to validate that the `target` option is a valid selector and not HTML. Since the plugin expects to attach scroll/click listeners to an existing element, we should use `$(document).find(this.options.target)` or similar, which will only search for elements matching the selector and will not create new elements from HTML. The change should be made in the Affix constructor, specifically on line 2237 in Plugson/www/static/bootstrap/js/bootstrap.js.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
