### PR TITLE
Potential fix for code scanning alert no. 14: DOM text reinterpreted as HTML

### DIFF
--- a/Plugson/www/static/bootstrap/js/bootstrap.js
+++ b/Plugson/www/static/bootstrap/js/bootstrap.js
@@ -783,7 +783,7 @@ if (typeof jQuery === 'undefined') {
 
     // Only allow selector if it is a safe CSS selector (starts with # or . and does not contain '<')
     var isSafeSelector = selector && (/^#[\w-]+$/.test(selector) || (/^\.[\w-]+$/.test(selector))) && selector.indexOf('<') === -1;
-    var $parent = isSafeSelector ? $(selector) : $this.parent();
+    var $parent = isSafeSelector ? $(document).find(selector) : $this.parent();
 
     return $parent && $parent.length ? $parent : $this.parent()
   }


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/14](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/14)

To fix the problem, we should avoid passing potentially untrusted data directly to the jQuery `$()` function, which can interpret the input as HTML and create DOM elements, leading to XSS. Instead, we should use `.find()` on a known safe context (such as `document` or a specific parent element), which interprets the input strictly as a selector and not as HTML. In this case, we can replace `$(selector)` with `$(document).find(selector)` when the selector is considered safe. This ensures that even if an attacker manages to inject a malicious selector, it will not be interpreted as HTML, thus preventing XSS.

The change should be made in the `getParent` function, specifically on line 786, where `$(selector)` is used. We should replace it with `$(document).find(selector)`. No new imports or definitions are needed, as jQuery is already available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
