### PR TITLE
Potential fix for code scanning alert no. 10: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/LinuxGUI/Ventoy2Disk/ventoy_gui.c
+++ b/LinuxGUI/Ventoy2Disk/ventoy_gui.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include <string.h>
 #include <stdarg.h>
 #include <unistd.h>
@@ -1201,11 +1203,16 @@ static int detect_gui_exe_path(int argc, char **argv, const char *curpath, char 
     if (access(pathbuf, X_OK) == -1)
     {
         vlog("execute permission check fail, try chmod.\n", pathbuf);
-        if (stat(pathbuf, &filestat) == 0)
+        int fd = open(pathbuf, O_RDONLY);
+        if (fd != -1)
         {
-            mode = filestat.st_mode | S_IXUSR | S_IXGRP | S_IXOTH;
-            ret = chmod(pathbuf, mode);
-            vlog("old mode=%o new mode=%o ret=%d\n", filestat.st_mode, mode, ret);
+            if (fstat(fd, &filestat) == 0)
+            {
+                mode = filestat.st_mode | S_IXUSR | S_IXGRP | S_IXOTH;
+                ret = fchmod(fd, mode);
+                vlog("old mode=%o new mode=%o ret=%d\n", filestat.st_mode, mode, ret);
+            }
+            close(fd);
         }
     }
     else


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/10](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/10)

To fix the TOCTOU vulnerability, we should avoid using the file path for both checking and modifying the file. Instead, we should open the file and use its file descriptor for permission changes. Specifically, after confirming the file exists and is not executable, we should open the file with `open(pathbuf, O_RDONLY)` (or `O_WRONLY` if appropriate), then use `fstat` to get its current mode and `fchmod` to set the new mode. This ensures that the permission change applies to the same file that was opened, even if the file at `pathbuf` is swapped out in the meantime.

Required changes:
- Include `<fcntl.h>` and `<unistd.h>` for `open`, `close`, and file descriptor operations.
- Replace the `stat` and `chmod` calls with `open`, `fstat`, and `fchmod` using the file descriptor.
- Ensure the file descriptor is closed after use.

All changes are within the region shown in LinuxGUI/Ventoy2Disk/ventoy_gui.c.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
