### PR TITLE
Potential fix for code scanning alert no. 15: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/LinuxGUI/Ventoy2Disk/ventoy_gui.c
+++ b/LinuxGUI/Ventoy2Disk/ventoy_gui.c
@@ -1194,31 +1194,34 @@ static int detect_gui_exe_path(int argc, char **argv, const char *curpath, char 
     vlog("This is %s%d X environment.\n", guitype, ver);
     vlog("exe = %s\n", pathbuf);
     
-    if (access(pathbuf, F_OK) == -1)
+    int fd = open(pathbuf, O_RDONLY);
+    if (fd == -1)
     {
-        vlog("%s is not exist.\n", pathbuf);
+        vlog("%s does not exist or cannot be opened.\n", pathbuf);
         return 1;
     }
 
-    if (access(pathbuf, X_OK) == -1)
+    if (fstat(fd, &filestat) == 0)
     {
-        vlog("execute permission check fail, try chmod.\n", pathbuf);
-        int fd = open(pathbuf, O_RDONLY);
-        if (fd != -1)
+        if ((filestat.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) == 0)
         {
-            if (fstat(fd, &filestat) == 0)
-            {
-                mode = filestat.st_mode | S_IXUSR | S_IXGRP | S_IXOTH;
-                ret = fchmod(fd, mode);
-                vlog("old mode=%o new mode=%o ret=%d\n", filestat.st_mode, mode, ret);
-            }
-            close(fd);
+            vlog("execute permission check fail, try chmod.\n");
+            mode = filestat.st_mode | S_IXUSR | S_IXGRP | S_IXOTH;
+            ret = fchmod(fd, mode);
+            vlog("old mode=%o new mode=%o ret=%d\n", filestat.st_mode, mode, ret);
+        }
+        else
+        {
+            vlog("execute permission check success.\n");
         }
     }
     else
     {
-        vlog("execute permission check success.\n");
+        vlog("fstat failed on %s\n", pathbuf);
+        close(fd);
+        return 1;
     }
+    close(fd);
 
     return 0;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/15](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/15)

To fix the TOCTOU race condition, avoid using `access` to check for file existence and permissions before opening the file. Instead, open the file first and then use `fstat` and `fchmod` on the file descriptor to check and set permissions. This ensures that all operations are performed on the same file, preventing an attacker from swapping the file between the check and the use.

**Detailed steps:**
- Remove the `access(pathbuf, X_OK)` check.
- Open the file directly (with appropriate flags, e.g., `O_RDONLY`).
- Use `fstat` to check if the file has execute permissions for the user/group/others.
- If not, use `fchmod` to set the execute permissions.
- Handle errors appropriately.
- Optionally, consider using `O_NOFOLLOW` to prevent following symlinks if security is a concern.

**Required changes:**
- Edit the region starting at line 1197 to remove the `access` checks and perform all permission checks and changes via the file descriptor.
- Ensure necessary headers are included (`#include <fcntl.h>`, `#include <sys/stat.h>`, if not already present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
