### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Ventoy CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/Ventoy/security/code-scanning/17](https://github.com/FlutterGenerator/Ventoy/security/code-scanning/17)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and uploads artifacts, it does not require any write permissions. The minimal required permission is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No additional methods, imports, or definitions are needed—just a YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
